### PR TITLE
Add initializer that takes a NavigationStack as parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,63 @@ NavigationStackView(transitionType: .custom(AnyTransition.scale.animation(.sprin
 
 attaching the easing directly to the transition. **Don't do this**. SwiftUI has still some problems with implicit animations attached to transitions, so it may not work. For example, implicit animations attached to a .slide transition won't work.
 
+## NavigationStack injection
+
+If you want to use the NavigationStack also outside the views hierachy you need to create you custom NavigationStack and pass it as parameter to the NavigationStackView.
+
+This is useful when you want to _decouple your routing logic from views by using your own router class_, for example:
+
+```
+class MyRouter {
+    let navStack: NavigationStack
+
+    init(navStack: NavigationStack) {
+        self.navStack = navStack
+    }
+
+    func rootView() {
+        if userIsLoggedIn() {
+            return HomeScreen()
+        } else {
+            return LoginScreen()
+        }
+    }
+
+    func toLogin() {
+        self.navStack.push(LoginScreen())
+    }
+
+    //...
+}
+
+struct ContentView: View {
+    let navStack: NavigationStack
+    let router: MyRouter
+
+    var body: some View {
+        NavigationStackView(navigationStack: navStack) {
+            router.rootView()
+        }
+    }
+}
+```
+
+Setup the ContentView in your SceneDelegate (or similarly in the App class)
+
+```
+// Create the SwiftUI view that provides the window contents.
+let contentView = ContentView(navStack: Injector.shared.navStack,
+                                router: Injector.shared.router)
+
+// Use a UIHostingController as window root view controller.
+if let windowScene = scene as? UIWindowScene {
+    let window = UIWindow(windowScene: windowScene)
+    window.rootViewController = UIHostingController(rootView: contentView)
+    self.window = window
+    window.makeKeyAndVisible()
+}
+```
+
 ## Push
 
 In order to navigate forward you have two options: 

--- a/README.md
+++ b/README.md
@@ -85,63 +85,6 @@ NavigationStackView(transitionType: .custom(AnyTransition.scale.animation(.sprin
 
 attaching the easing directly to the transition. **Don't do this**. SwiftUI has still some problems with implicit animations attached to transitions, so it may not work. For example, implicit animations attached to a .slide transition won't work.
 
-## NavigationStack injection
-
-If you want to use the NavigationStack also outside the views hierachy you need to create you custom NavigationStack and pass it as parameter to the NavigationStackView.
-
-This is useful when you want to _decouple your routing logic from views by using your own router class_, for example:
-
-```
-class MyRouter {
-    let navStack: NavigationStack
-
-    init(navStack: NavigationStack) {
-        self.navStack = navStack
-    }
-
-    func rootView() {
-        if userIsLoggedIn() {
-            return HomeScreen()
-        } else {
-            return LoginScreen()
-        }
-    }
-
-    func toLogin() {
-        self.navStack.push(LoginScreen())
-    }
-
-    //...
-}
-
-struct ContentView: View {
-    let navStack: NavigationStack
-    let router: MyRouter
-
-    var body: some View {
-        NavigationStackView(navigationStack: navStack) {
-            router.rootView()
-        }
-    }
-}
-```
-
-Setup the ContentView in your SceneDelegate (or similarly in the App class)
-
-```
-// Create the SwiftUI view that provides the window contents.
-let contentView = ContentView(navStack: Injector.shared.navStack,
-                                router: Injector.shared.router)
-
-// Use a UIHostingController as window root view controller.
-if let windowScene = scene as? UIWindowScene {
-    let window = UIWindow(windowScene: windowScene)
-    window.rootViewController = UIHostingController(rootView: contentView)
-    self.window = window
-    window.makeKeyAndVisible()
-}
-```
-
 ## Push
 
 In order to navigate forward you have two options: 
@@ -335,6 +278,47 @@ struct ChildView: View {
 }
 ```
 
+## NavigationStack injection
+
+By default you can programmatically push and pop only inside the `NavigationStackView` hierarchy (by accessing the `NavigationStack` environment object). If you want to use the `NavigationStack` outside the `NavigationStackView` you need to create your own `NavigationStack` (wherever you want) **and pass it as parameter to the `NavigationStackView`**.
+
+**Important:** Every `NavigationStack` must be associated to a `NavigationStackView`. A `NavigationStack` cannot be shared between multiple `NavigationStackView`.
+
+This is useful when you want to _decouple your routing logic from views by using your own router class_, for example:
+
+```
+class MyRouter {
+    private let navStack: NavigationStack
+
+    init(navStack: NavigationStack) {
+        self.navStack = navStack
+    }
+
+    func rootView() -> some View {
+        RootView()
+    }
+
+    func toLogin() {
+        self.navStack.push(LoginScreen())
+    }
+
+    func toSignUp() {
+        self.navStack.push(SignUpScreen())
+    }
+}
+
+struct RootView: View {
+    let navStack: NavigationStack
+    let router: MyRouter
+
+    var body: some View {
+        NavigationStackView(navigationStack: navStack) {
+            router.rootView()
+        }
+    }
+}
+```
+
 ## Important
 
 Please, note that `NavigationStackView` navigates between views and two views may be smaller than the entire screen. In that case the transition animation won't involve the whole screen, but just the two views. Let's make an example:
@@ -468,5 +452,3 @@ struct MyView: View {
 
 SwiftUI is really new, there are some bugs in the framework (or unexpected behaviours) and several API not yet documented. Please, report any issue may arise and feel free to suggest any improvement or changing to this first implementation of a navigation stack.
  
-
-

--- a/Sources/NavigationStack/NavigationStack.swift
+++ b/Sources/NavigationStack/NavigationStack.swift
@@ -47,14 +47,14 @@ public enum PopDestination {
 public class NavigationStack: ObservableObject {
 
     /// Default transition animation
-    public static let defaultAnimation = Animation.easeOut(duration: 0.2)
+    public static let defaultEasing = Animation.easeOut(duration: 0.2)
 
     fileprivate private(set) var navigationType = NavigationType.push
 
     /// Customizable easing to apply in pop and push transitions
     private let easing: Animation
 
-    public init(easing: Animation = defaultAnimation) {
+    public init(easing: Animation = defaultEasing) {
         self.easing = easing
     }
 
@@ -158,7 +158,7 @@ public struct NavigationStackView<Root>: View where Root: View {
     ///   - transitionType: The type of transition to apply between views in every push and pop operation.
     ///   - easing: The easing function to apply to every push and pop operation.
     ///   - rootView: The very first view in the NavigationStack.
-    public init(transitionType: NavigationTransition = .default, easing: Animation = NavigationStack.defaultAnimation, @ViewBuilder rootView: () -> Root) {
+    public init(transitionType: NavigationTransition = .default, easing: Animation = NavigationStack.defaultEasing, @ViewBuilder rootView: () -> Root) {
         self.init(transitionType: transitionType, navigationStack: NavigationStack(easing: easing), rootView: rootView)
     }
 

--- a/Sources/NavigationStack/NavigationStack.swift
+++ b/Sources/NavigationStack/NavigationStack.swift
@@ -45,11 +45,16 @@ public enum PopDestination {
 // MARK: ViewModel
 
 public class NavigationStack: ObservableObject {
+
+    /// Default transition animation
+    public static let defaultAnimation = Animation.easeOut(duration: 0.2)
+
     fileprivate private(set) var navigationType = NavigationType.push
+
     /// Customizable easing to apply in pop and push transitions
     private let easing: Animation
 
-    public init(easing: Animation = .easeOut(duration: 0.2)) {
+    public init(easing: Animation = defaultAnimation) {
         self.easing = easing
     }
 
@@ -153,7 +158,7 @@ public struct NavigationStackView<Root>: View where Root: View {
     ///   - transitionType: The type of transition to apply between views in every push and pop operation.
     ///   - easing: The easing function to apply to every push and pop operation.
     ///   - rootView: The very first view in the NavigationStack.
-    public init(transitionType: NavigationTransition = .default, easing: Animation = .easeOut(duration: 0.2), @ViewBuilder rootView: () -> Root) {
+    public init(transitionType: NavigationTransition = .default, easing: Animation = NavigationStack.defaultAnimation, @ViewBuilder rootView: () -> Root) {
         self.init(transitionType: transitionType, navigationStack: NavigationStack(easing: easing), rootView: rootView)
     }
 

--- a/Sources/NavigationStack/NavigationStack.swift
+++ b/Sources/NavigationStack/NavigationStack.swift
@@ -48,11 +48,11 @@ public class NavigationStack: ObservableObject {
     fileprivate private(set) var navigationType = NavigationType.push
     /// Customizable easing to apply in pop and push transitions
     private let easing: Animation
-    
-    init(easing: Animation) {
+
+    public init(easing: Animation = .easeOut(duration: 0.2)) {
         self.easing = easing
     }
-    
+
     private var viewStack = ViewStack() {
         didSet {
             currentView = viewStack.peek()
@@ -154,8 +154,17 @@ public struct NavigationStackView<Root>: View where Root: View {
     ///   - easing: The easing function to apply to every push and pop operation.
     ///   - rootView: The very first view in the NavigationStack.
     public init(transitionType: NavigationTransition = .default, easing: Animation = .easeOut(duration: 0.2), @ViewBuilder rootView: () -> Root) {
+        self.init(transitionType: transitionType, navigationStack: NavigationStack(easing: easing), rootView: rootView)
+    }
+
+    /// Creates a NavigationStackView with the provided NavigationStack
+    /// - Parameters:
+    ///   - transitionType: The type of transition to apply between views in every push and pop operation.
+    ///   - navigationStack: the shared NavigationStack
+    ///   - rootView: The very first view in the NavigationStack.
+    public init(transitionType: NavigationTransition = .default, navigationStack: NavigationStack, @ViewBuilder rootView: () -> Root) {
         self.rootView = rootView()
-        self.navViewModel = NavigationStack(easing: easing)
+        self.navViewModel = navigationStack
         switch transitionType {
         case .none:
             self.transitions = (.identity, .identity)


### PR DESCRIPTION
_Added init method that takes a NavigationStack as parameter._

The NavigationStack is only available as EnvironmentObject and there's no way to get the injected instance outside the view hierachy.
This new init allows to create a NavigationStackView with a shared instance of the NavigationStack making it possible to be used also outside the view.

**Case of use:**

```
class Injector {

    static var shared = Injector()

    lazy var navStack: NavigationStack = NavigationStack(easing: .default)

    lazy var router: Router = Router(navStack: self.navStack)
}

struct ContentView: View {
    let navStack: NavigationStack
    let router: Router

    var body: some View {
        NavigationStackView(navigationStack: navStack) {
            router.rootView()
        }
    }
}
```

In the scene delegate or app file

```
       // Create the SwiftUI view that provides the window contents.
        let contentView = ContentView(navStack: Injector.shared.navStack,
                                      router: Injector.shared.router)

        // Use a UIHostingController as window root view controller.
        if let windowScene = scene as? UIWindowScene {
            let window = UIWindow(windowScene: windowScene)
            window.rootViewController = UIHostingController(rootView: contentView)
            self.window = window
            window.makeKeyAndVisible()
        }
```