### PR TITLE
Add z index to the views being pushed and popped so that the views appear on top of each other.

### DIFF
--- a/Sources/NavigationStack/NavigationStack.swift
+++ b/Sources/NavigationStack/NavigationStack.swift
@@ -196,6 +196,7 @@ public struct NavigationStackView<Root>: View where Root: View {
                         .id(navViewModel.currentView!.id)
                         .transition(navigationType == .push ? transitions.push : transitions.pop)
                         .environmentObject(navViewModel)
+                        .zIndex(navigationType == .push ? 1 : 0)
                 }
             }
         }


### PR DESCRIPTION
Hi @matteopuc! I really love the work you did on the NavigationStackView and I think it's a really grate alternative for the SwiftUI default NavigationView.

I started using it and wanted to create a custom transition, one that mimics the iOS's push and pop transition where the view being pushed goes on top of the other. Like this:

https://i.stack.imgur.com/Lmb7G.gif

Unfortunately in the current implementation the currentView will always appear on top (even when popping) and I got something like this:


https://user-images.githubusercontent.com/6979282/106283321-74b43080-624a-11eb-8a51-9f20dd7572a5.mov

To get the effect I wanted I added a `zIndex` to the pushed and popped views.

https://user-images.githubusercontent.com/6979282/106283725-eee4b500-624a-11eb-9806-c70d8877d3fc.mov

I am writing this pull request as an idea, please take a look at it and disregard it if you think it's not in the direction you want to take your project 😄 .