### PR TITLE
Added the watchOS platform to the Package.swift file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,4 @@
+# swiftui-navigation-stack Changelog
+
+## 1.0.3
+- Fixed Package.swift: the watchOS platform was missing.

--- a/Package.swift
+++ b/Package.swift
@@ -7,7 +7,8 @@ let package = Package(
     name: "NavigationStack",
     platforms: [
         .iOS(.v13),
-        .macOS(.v10_15)
+        .macOS(.v10_15),
+        .watchOS(.v6)
     ],
     products: [
         // Products define the executables and libraries produced by a package, and make them visible to other packages.


### PR DESCRIPTION
WatchOS was missing from the Package.swift file.